### PR TITLE
Added support for 2d indices via MongoMeta

### DIFF
--- a/tests/mongodb/models.py
+++ b/tests/mongodb/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from djangotoolbox.fields import RawField, ListField, EmbeddedModelField
 from django_mongodb_engine.fields import GridFSField, GridFSString
 from query.models import Post
+from pymongo import ASCENDING
 
 class DescendingIndexModel(models.Model):
     desc = models.IntegerField()
@@ -29,18 +30,22 @@ class IndexTestModel(models.Model):
     geo_index = ListField(db_index=True)
 
     class MongoMeta:
-        sparse_indexes = ["sparse_index", "sparse_index_unique", ('sparse_index_cmp_1', 'sparse_index_cmp_2')]
+        sparse_indexes = ["sparse_index", "sparse_index_unique", 
+                          ('sparse_index_cmp_1', 'sparse_index_cmp_2')]
         descending_indexes = ['descending_index', 'descending_index_custom_column']
-        geo_indexes = ['geo_index']
+        geo_index = ['geo_index', ('regular_index',ASCENDING)]
         index_together = [{ 'fields' : ['regular_index', 'custom_column']},
                           { 'fields' : ('sparse_index_cmp_1', 'sparse_index_cmp_2')}]
 
 class IndexTestModel2(models.Model):
     a = models.IntegerField(db_index=True)
     b = models.IntegerField(db_index=True)
+    geo_index = ListField(db_index=True)
 
     class MongoMeta:
         index_together = ['a', ('b', -1)]
+        geo_index = {'fields' : ['geo_index','a'], 'min' : -10, 
+                     'max' : 15, 'name' : 'GeoIndex'}
 
 class GridFSFieldTestModel(models.Model):
     gridfile = GridFSField()


### PR DESCRIPTION
I looked through the code pretty thoroughly and I couldn't figure out a way to do this without any coding changes. Critiques to my coding still are welcome, of course; I'm far from a Mongodb or Django veteran.

I got one error in runtests.py on a fresh install. The error count remains the same, but of course that could be hiding a regression.

```
ERROR: test_tellsiteid (mongodb.tests.MongoDBEngineTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sib/Devel/mongodb-engine/tests/mongodb/tests.py", line 108, in test_tellsiteid
    call_command('tellsiteid', stdout=stdout, **kwargs)
  File "/home/sib/Devel/mongodb-engine/lib/python2.7/site-packages/django/core/management/__init__.py", line 155, in call_command
    raise CommandError("Unknown command: %r" % name)
CommandError: Unknown command: 'tellsiteid'
```

---
