### PR TITLE
Allow dot notation indices of embedded documents

### DIFF
--- a/tests/mongodb/models.py
+++ b/tests/mongodb/models.py
@@ -44,34 +44,35 @@ class CustomColumnEmbeddedModel(models.Model):
     a = models.IntegerField(db_column='a2')
 
 class NewStyleIndexesTestModel(models.Model):
-    a = models.IntegerField()
-    b = models.IntegerField(db_column='b2')
-    c = models.IntegerField(db_index=True)
-    d = models.IntegerField()
-    e = models.IntegerField()
-    f = models.IntegerField(unique=True)
+    f1 = models.IntegerField()
+    f2 = models.IntegerField()
+    f3 = models.IntegerField()
+
+    db_index = models.IntegerField(db_index=True)
+    unique = models.IntegerField(unique=True)
+    custom_column = models.IntegerField(db_column='custom')
     geo = models.IntegerField()
-    geo2 = models.IntegerField(db_column='geo')
-    # Embedded Keys
-    h = DictField()
-    i = DictField(db_column='i2')
-    # Embedded Keys in Embedded Models
-    j = EmbeddedModelField(CustomColumnEmbeddedModel)
-    k = ListField(EmbeddedModelField(CustomColumnEmbeddedModel))
+    geo_custom_column = models.IntegerField(db_column='geo')
+
+    dict1 = DictField()
+    dict_custom_column = DictField(db_column='dict_custom')
+    embedded = EmbeddedModelField(CustomColumnEmbeddedModel)
+    embedded_list = ListField(EmbeddedModelField(CustomColumnEmbeddedModel))
+
     class Meta:
-        unique_together = [('a', 'b'), ('a', 'd')]
+        unique_together = [('f2', 'custom_column'), ('f2', 'f3')]
 
     class MongoMeta:
         indexes = [
-            [('e', -1)],
-            {'fields': 'a', 'sparse': True},
-            {'fields': [('b', -1), 'd']},
+            [('f1', -1)],
+            {'fields': 'f2', 'sparse': True},
+            {'fields': [('custom_column', -1), 'f3']},
             [('geo', '2d')],
-            {'fields': [('geo2', '2d'), 'a'], 'min': 42, 'max': 21},
-            {'fields': [('h.q',1)]},
-            {'fields': [('i.q',1)]},
-            {'fields' :[('j.a',1)]},
-            {'fields' :[('k.a',1)]},
+            {'fields': [('geo_custom_column', '2d'), 'f2'], 'min': 42, 'max': 21},
+            {'fields': [('dict1.foo', 1)]},
+            {'fields': [('dict_custom_column.foo', 1)]},
+            {'fields' :[('embedded.a', 1)]},
+            {'fields' :[('embedded_list.a', 1)]},
 
         ]
 

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -337,19 +337,19 @@ class NewStyleIndexTests(TestCase):
         self.assertEqual(info[index_name], dict(default_properties, **properties))
 
     def test_indexes(self):
-        self.assertHaveIndex([('c', 1)])
-        self.assertHaveIndex([('f', 1)], unique=True)
-        self.assertHaveIndex([('a', 1), ('b2', 1)], unique=True)
-        self.assertHaveIndex([('a', 1), ('d', 1)], unique=True)
-        self.assertHaveIndex([('e', -1)])
-        self.assertHaveIndex([('a', 1)], sparse=True)
-        self.assertHaveIndex([('b2', -1), ('d', 1)])
+        self.assertHaveIndex([('db_index', 1)])
+        self.assertHaveIndex([('unique', 1)], unique=True)
+        self.assertHaveIndex([('f2', 1), ('custom', 1)], unique=True)
+        self.assertHaveIndex([('f2', 1), ('f3', 1)], unique=True)
+        self.assertHaveIndex([('f1', -1)])
+        self.assertHaveIndex([('f2', 1)], sparse=True)
+        self.assertHaveIndex([('custom', -1), ('f3', 1)])
         self.assertHaveIndex([('geo', '2d')])
-        self.assertHaveIndex([('geo', '2d'), ('a', 1)], min=42, max=21)
-        self.assertHaveIndex([('h.q', 1)])
-        self.assertHaveIndex([('i2.q', 1)])
-        self.assertHaveIndex([('j.a2',1)])
-        self.assertHaveIndex([('k.a2',1)])
+        self.assertHaveIndex([('geo', '2d'), ('f2', 1)], min=42, max=21)
+        self.assertHaveIndex([('dict1.foo', 1)])
+        self.assertHaveIndex([('dict_custom.foo', 1)])
+        self.assertHaveIndex([('embedded.a2', 1)])
+        self.assertHaveIndex([('embedded_list.a2', 1)])
 
 class GridFSFieldTests(TestCase):
     def tearDown(self):


### PR DESCRIPTION
I mentioned earlier on the mailing list that I wanted to index embedded documents, as Mongo allows, and I was curious as to weather it was possible. It wasn't, so I did my best to fix it.

I made sure to preserve column aliases at the root level, but in the case of embedded models I do not currently check for aliases. Is this an important feature, or is what I've written reasonable?
