### PR TITLE
Automatically create sparse indexes in unique and null fields

### DIFF
--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -340,6 +340,16 @@ class SQLCompiler(NonrelCompiler):
     def _save(self, data, return_id=False):
         collection = self.get_collection()
         options = self.connection.operation_flags.get('save', {})
+
+        # Check for fields set to None
+        if None in data.values():
+            # Check if we have null + unique fields set to None. If so delete
+            # those from data, so that the sparse index works
+            fields = self.get_fields()
+            for field in fields:
+                if field.null and field.unique and data[field.column] is None:
+                    del data[field.column] 
+
         if data.get('_id', NOT_PROVIDED) is None:
             if len(data) == 1:
                 # insert with empty model

--- a/django_mongodb_engine/creation.py
+++ b/django_mongodb_engine/creation.py
@@ -39,10 +39,12 @@ class DatabaseCreation(NonrelDatabaseCreation):
 
         # Django indexes
         for field in meta.local_fields:
+            column = '_id' if field.primary_key else field.column
+            if field.unique and field.null:
+                ensure_index(column, unique=True, sparse=True)
             if not (field.unique or field.db_index):
                 # field doesn't need an index
                 continue
-            column = '_id' if field.primary_key else field.column
             ensure_index(column, unique=field.unique)
 
         # Django unique_together indexes
@@ -90,10 +92,12 @@ class DatabaseCreation(NonrelDatabaseCreation):
 
         # Ordinary indexes
         for field in meta.local_fields:
+            column = '_id' if field.primary_key else field.column
+            if field.unique and field.null:
+                ensure_index(column, unique=True, sparse=True)
             if not (field.unique or field.db_index):
                 # field doesn't need an index
                 continue
-            column = '_id' if field.primary_key else field.column
             if field.name in descending_indexes:
                 column = [(column, DESCENDING)]
             ensure_index(column, unique=field.unique,


### PR DESCRIPTION
When you allow null in a unique field, you expect to be able to introduce several nulls in that column field. This code generates the sparse indexes on those fields automatically. Otherwise you can forget to create the indexes and get bitten by it in the future.
