### PR TITLE
Add test for atomic update with F of a field with a different db_column

### DIFF
--- a/tests/query/models.py
+++ b/tests/query/models.py
@@ -25,6 +25,7 @@ class Person(models.Model):
     name = models.CharField(max_length=20)
     surname = models.CharField(max_length=20)
     age = models.IntegerField(null=True, blank=True)
+    another_age = models.IntegerField(null=True, blank=True, db_column='age2')
 
     class Meta:
         unique_together = ("name", "surname")

--- a/tests/query/tests.py
+++ b/tests/query/tests.py
@@ -375,6 +375,17 @@ class UpdateTests(TestCase):
         Person.objects.filter(name='john').update(age=F('age')-10)
         self.assertEqual(Person.objects.get(name='john').age, 39)
 
+    def test_update_with_F_and_db_column(self):
+        # This test is simmilar to test_update_with_F but tests
+        # the update with a column that has a db_column set.
+        john = Person.objects.create(name='john', surname='nhoj', another_age=42)
+        andy = Person.objects.create(name='andy', surname='ydna', another_age=-5)
+        Person.objects.update(another_age=F('another_age')+7)
+        self.assertEqual(Person.objects.get(pk=john.id).another_age, 49)
+        self.assertEqual(Person.objects.get(id=andy.pk).another_age, 2)
+        Person.objects.filter(name='john').update(another_age=F('another_age')-10)
+        self.assertEqual(Person.objects.get(name='john').another_age, 39)
+
     def test_invalid_update_with_F(self):
         self.assertRaises(AssertionError, Person.objects.update, age=F('name')+1)
 


### PR DESCRIPTION
Atomic updates with F do not work when the field uses a different db_column.

For now I have only prepared a test, which shows the wrong behavior.
