### PR TITLE
Remove annoying print when tests run.

### DIFF
--- a/django_mongodb_engine/creation.py
+++ b/django_mongodb_engine/creation.py
@@ -23,7 +23,7 @@ class DatabaseCreation(NonrelDatabaseCreation):
 
         def ensure_index(*args, **kwargs):
             if ensure_index.first_index:
-                print "Installing indices for %s.%s model" % (meta.app_label, meta.object_name)
+                # print "Installing indices for %s.%s model" % (meta.app_label, meta.object_name)
                 ensure_index.first_index = False
             return collection.ensure_index(*args, **kwargs)
         ensure_index.first_index = True


### PR DESCRIPTION
Remove annoying "Installing indicies for ..." prints when running tests.
