### PR TITLE
Added max_length to CharField in docs

### DIFF
--- a/docs/source/reference/model-options.rst
+++ b/docs/source/reference/model-options.rst
@@ -53,7 +53,7 @@ For example, a logging collection fixed to 50MiB could be defined as follows::
 
    class LogEntry(models.Model):
        timestamp = models.DateTimeField()
-       message = models.CharField()
+       message = models.TextField()
        ...
        class MongoMeta:
            capped = True

--- a/docs/source/topics/embedded-models.rst
+++ b/docs/source/topics/embedded-models.rst
@@ -117,7 +117,7 @@ your data records. If you want to use them anyway, here's how you'd do it::
        foo = models.IntegerField()
 
    class BarModel(models.Model):
-       bar = models.CharField()
+       bar = models.CharField(max_length=255)
 
 ::
 
@@ -126,4 +126,4 @@ your data records. If you want to use them anyway, here's how you'd do it::
    )
 
 .. _MongoDB's subobjects: http://www.mongodb.org/display/DOCS/Dot+Notation+(Reaching+into+Objects)
-.. _generic relations: http://docs.djangoproject.com/en/dev/ref/contrib/contenttypes/ 
+.. _generic relations: http://docs.djangoproject.com/en/dev/ref/contrib/contenttypes/

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -70,7 +70,7 @@ So, adding a new field boils down to... adding a new field. ::
 
    class Post(models.Model):
        created_on = models.DateTimeField(auto_now_add=True, null=True) # <---
-       title = models.CharField()
+       title = models.CharField(max_length=255)
        text = models.TextField()
        tags = ListField()
        comments = ListField()
@@ -107,7 +107,7 @@ Let's first design our model for comments. ::
 
    class Comment(models.Model):
        created_on = models.DateTimeField(auto_now_add=True)
-       author_name = models.CharField()
+       author_name = models.CharField(max_length=255)
        author_email = models.EmailField()
        text = models.TextField()
 


### PR DESCRIPTION
CharFields require max_length - added to the docs.

Refs: http://stackoverflow.com/questions/9727760/mongo-working-with-django-max-length-issue-for-charfield
