### PR TITLE
Python 2.5 fixes

### DIFF
--- a/tests/contrib/tests.py
+++ b/tests/contrib/tests.py
@@ -7,8 +7,8 @@ from django.db.utils import DatabaseError
 
 from django_mongodb_engine.contrib import MapReduceResult
 
-from contrib.models import *
-from contrib.utils import TestCase, get_collection, skip
+from models import *
+from utils import TestCase, get_collection, skip
 
 
 class MapReduceTests(TestCase):

--- a/tests/embedded/tests.py
+++ b/tests/embedded/tests.py
@@ -1,7 +1,7 @@
 from django_mongodb_engine.query import A
 
-from embedded.models import *
-from embedded.utils import TestCase, get_collection
+from models import *
+from utils import TestCase, get_collection
 
 
 class EmbeddedModelFieldTestCase(TestCase):

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -13,8 +13,8 @@ from pymongo import ASCENDING, DESCENDING
 from django_mongodb_engine.base import DatabaseWrapper
 from django_mongodb_engine.serializer import LazyModelInstance
 
-from mongodb.models import *
-from mongodb.utils import *
+from models import *
+from utils import *
 
 
 class MongoDBEngineTests(TestCase):

--- a/tests/query/tests.py
+++ b/tests/query/tests.py
@@ -6,9 +6,8 @@ from django.db.utils import DatabaseError
 
 from pymongo.objectid import ObjectId
 
-from query.models import *
-from query.utils import *
-
+from models import *
+from utils import *
 
 
 class BasicQueryTests(TestCase):


### PR DESCRIPTION
Bikeshedding: Can the test imports be changed to `from tests.foo.bar import spam?` Because `from mongodb import ...` might suggest there's a `mongodb` Python module.
