### PR TITLE
Implementation of distinct()

### DIFF
--- a/django_mongodb_engine/contrib/__init__.py
+++ b/django_mongodb_engine/contrib/__init__.py
@@ -133,7 +133,7 @@ class MongoDBQuerySet(QuerySet):
 
     def distinct(self, *args, **kwargs):
         query = self._get_query()
-        return query.collection.distinct(*args, **kwargs)
+        return query._get_results().distinct(*args, **kwargs)
 
 class MongoDBManager(models.Manager, RawQueryMixin):
     """

--- a/tests/contrib/tests.py
+++ b/tests/contrib/tests.py
@@ -204,3 +204,5 @@ class DistinctTests(TestCase):
 
         self.assertEqual(MapReduceModel.objects.distinct('m'),
                         [2, 4, 6, 8, 10, 12, 14, 16, 18])
+                        
+        self.assertEqual(MapReduceModel.objects.filter(n=6).distinct('m'), [12])


### PR DESCRIPTION
Hi All,

I saw that distinct() was added (https://github.com/django-nonrel/mongodb-engine/commit/efcebec036d00b2e3da76f685329e6e6650bcc8f) but did not have cause to use it until today.

It seemed possible to chain distinct() with filter():

``` python
from django_mongodb_engine.contrib import MongoDBManager

class FooModel(models.Model):
    ...
    objects = MongoDBManager()

FooModel.objects.filter(filters).distinct(fields)
```

in that code of the above form executes without error.

However the filters are ignored as distinct() is called on the pymongo Collection, not on the pymongo Cursor from the query result.

I'm not sure what the intention was with distinct() but I lost several hours to this today and wondered whether it should either be amended to work with filter() or raise an exception when called on a QuerySet.  Either could help future hapless coders like me.

I've had a go at making it work with filter() and welcome your feedback.

Dan
