### PR TITLE
Implementation of distinct()

### DIFF
--- a/django_mongodb_engine/contrib/__init__.py
+++ b/django_mongodb_engine/contrib/__init__.py
@@ -148,7 +148,7 @@ class MongoDBQuerySet(QuerySet):
 
     def distinct(self, *args, **kwargs):
         query = self._get_query()
-        return query.collection.distinct(*args, **kwargs)
+        return query._get_results().distinct(*args, **kwargs)
 
 
 class MongoDBManager(models.Manager, RawQueryMixin):

--- a/tests/contrib/tests.py
+++ b/tests/contrib/tests.py
@@ -241,3 +241,5 @@ class DistinctTests(TestCase):
 
         self.assertEqual(MapReduceModel.objects.distinct('m'),
                          [2, 4, 6, 8, 10, 12, 14, 16, 18])
+
+        self.assertEqual(MapReduceModel.objects.filter(n=6).distinct('m'), [12])


### PR DESCRIPTION
Replacement for https://github.com/django-nonrel/mongodb-engine/pull/120 on develop branch.

It did strike me after sending the last pull request that our distinct() returns the result of the distinct query as a list, whereas https://docs.djangoproject.com/en/dev/ref/models/querysets/#distinct returns a new QuerySet.  Given the mongodb implementation, I don't think its possible to replicate the behavior of django's distinct() in various ways but I thought I'd note this, should anyone wants to rename to mongo_distinct() or something else that makes the difference clear.  I'm happy as it is though :-)

Thank you all for your help.
