### PR TITLE
Pymongo has removed objectid, which has been deprecated 

### DIFF
--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -15,7 +15,14 @@ from django.utils.tree import Node
 
 from pymongo.errors import PyMongoError, DuplicateKeyError
 from pymongo import ASCENDING, DESCENDING
-from pymongo.objectid import ObjectId, InvalidId
+
+import warnings
+try:
+    from pymongo.objectid import ObjectId, InvalidId
+    warnings.warn("pymongo.objectid deprecated, use bson.objectid and bson.errors instead")
+except ImportError:
+    from bson.objectid import ObjectId
+    from bson.errors import InvalidId
 
 from djangotoolbox.db.basecompiler import NonrelQuery, NonrelCompiler, \
     NonrelInsertCompiler, NonrelUpdateCompiler, NonrelDeleteCompiler


### PR DESCRIPTION
This was removed Monday with the new version 2.2. The bson module should be used instead.
