### PR TITLE
Enable mongodb_engine support MongoDB ReplicaSet Client

### DIFF
--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -141,8 +141,8 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
             if read_preference:
                 warnings.warn("slave_okay has been deprecated. Please use read_preference")
         try:
-           if read_preference:
-                Connection = RelicaSetConnection
+            if read_preference:
+                Connection = ReplicaSetConnection
             self.connection = Connection(host=host, port=port, **options)
             self.database = self.connection[db_name]
         except TypeError:


### PR DESCRIPTION
django_mongodb_engine supports only MongoClient, but not MongoReplicaSetClient. This request replaced the defaut connection to MongoReplicaSetClient if  any of read_preference, slave_okay, slaveok options was set in database conf. 

And a warning was added if slave_okay, or slaveok was used in options, as both of them are deprecated settings in pymongo. 
