### PR TITLE
enable mongodb engine support mongodb replicaset client

### DIFF
--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -10,8 +10,8 @@ from django.db.backends.signals import connection_created
 from django.db.utils import DatabaseError
 
 from pymongo.collection import Collection
-from pymongo.mongo_client import MongoClient as Connection
-from pymongo.mongo_replica_set_client import MongoReplicaSetClient as ReplicaSetConnection
+from pymongo.mongo_client import MongoClient
+from pymongo.mongo_replica_set_client import MongoReplicaSetClient
 
 # handle pymongo backward compatibility
 try:
@@ -238,7 +238,9 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
 
         try:
             if read_preference:
-               Connection = ReplicaSetConnection
+                Connection = ReplicaSetMongoClient
+            else:
+                Connection = MongoClient
 
             self.connection = Connection(host=host, port=port, **options)
             self.database = self.connection[db_name]


### PR DESCRIPTION
django_mongodb_engine supports only MongoClient, but not MongoReplicaSetClient. This request replaced the defaut connection to MongoReplicaSetClient if any of read_preference, slave_okay, slaveok options was set in database conf.

And a warning was added if slave_okay, or slaveok was used in options, as both of them are deprecated settings in pymongo.
