### PR TITLE
Use MongoClient or MongoReplicaSet client instead of Connection

### DIFF
--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -55,7 +55,7 @@ class MongoDBEngineTests(TestCase):
             self.assertEqual(RawModel.objects.get(id=id).raw, obj)
 
     def test_databasewrapper_api(self):
-        from pymongo.connection import Connection
+        from pymongo.mongo_client import MongoClient
         from pymongo.database import Database
         from pymongo.collection import Collection
         from random import shuffle
@@ -70,7 +70,7 @@ class MongoDBEngineTests(TestCase):
                 lambda: self.assertIsInstance(wrapper.get_collection('foo'),
                                               Collection),
                 lambda: self.assertIsInstance(wrapper.database, Database),
-                lambda: self.assertIsInstance(wrapper.connection, Connection),
+                lambda: self.assertIsInstance(wrapper.connection, MongoClient),
             ]
             shuffle(calls)
             for call in calls:


### PR DESCRIPTION
Pymongo Connection class is deprecated now so we have to switch to MongoClient/MongoReplicaSetClient at some point.
