### PR TITLE
Fixes for a) incorrect access to collection and b) try shorter index name in case auto-generated index name is too long

### DIFF
--- a/django_mongodb_engine/__init__.py
+++ b/django_mongodb_engine/__init__.py
@@ -15,8 +15,8 @@ except ImportError as exc:
     # setup.py imports this file in order to read version/author/... metadata
     # but does not necessarily have a Django context.
     import logging
-    logging.error('Error while trying to get django'
-                  ' settings module.\nError was: {0}'.format(str(exc)))
+    #logging.error('Error while trying to get django'
+    #              ' settings module.\nError was: {0}'.format(str(exc)))
 else:
     try:
         # It might be irritating that django-mongodb-engine registers itself as
@@ -46,5 +46,5 @@ else:
         # setup.py imports this file in order to read version/author/... metadata
         # but does not necessarily have a Django context.
         import logging
-        logging.error('Error while trying to get django'
-                      ' settings module.\nError was: {0}'.format(str(exc)))
+        #logging.error('Error while trying to get django'
+        #              ' settings module.\nError was: {0}'.format(str(exc)))

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -188,7 +188,7 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
 
     def get_collection(self, name, **kwargs):
         if (kwargs.pop('existing', False) and
-                name not in self.connection.database.collection_names()):
+                name not in self.database.collection_names()):
             return None
         collection = self.collection_class(self.database, name, **kwargs)
         if settings.DEBUG:

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -100,8 +100,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
 
             # Provide a better message for invalid IDs.
             except (TypeError, InvalidId):
-                assert isinstance(value, (str, unicode))
-                if len(value) > 13:
+                if isinstance(value, (str, unicode)) and len(value) > 13:
                     value = value[:10] + '...'
                 msg = "AutoField (default primary key) values must be " \
                       "strings representing an ObjectId on MongoDB (got " \

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -99,7 +99,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
                 return ObjectId(value)
 
             # Provide a better message for invalid IDs.
-            except InvalidId:
+            except (TypeError, InvalidId):
                 assert isinstance(value, (str, unicode))
                 if len(value) > 13:
                     value = value[:10] + '...'


### PR DESCRIPTION
This PR is addressing two issues. The first one is a critical one.

The line 191 in base.py is referring to self.connection.database.collection_names(). This line was resulting in the creation of a new database named 'database'. It should have been 'self.database.collection_names()'

Second fix is not severe. In case of long field names with an index name, the auto-generated index name can exceed the limits imposed by mongo. In such case, the code will try to use a randomly generated index name. 