### PR TITLE
PyMongo 3 compatibility.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 Version 0.5.2 (TBD)
 -----------------
 * Add support for Replica Sets (Thanks @r4fek)
+* PyMongo 3 support
 
 
 Version 0.5.1 (Nov 2013)

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -248,12 +248,8 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
         conn_options = dict(
             host=host,
             port=int(port),
-            max_pool_size=None,
             document_class=dict,
             tz_aware=False,
-            _connect=True,
-            auto_start_request=True,
-            safe=False
         )
         conn_options.update(options)
 

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -234,7 +234,9 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
         replicaset = options.get('replicaset')
 
         if not read_preference:
-            read_preference = options.get('slave_okay', options.get('slaveok'))
+            read_preference = options.pop('slave_okay',
+                                          options.pop('slaveok', None))
+
             if read_preference:
                 options['read_preference'] = ReadPreference.SECONDARY
                 warnings.warn("slave_okay has been deprecated. "

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -136,7 +136,7 @@ class MongoQuery(NonrelQuery):
             return []
 
         fields = get_selected_fields(self.query)
-        cursor = self.collection.find(self.mongo_query, fields=fields)
+        cursor = self.collection.find(self.mongo_query, fields)
         if self.ordering:
             cursor.sort(self.ordering)
         if self.query.low_mark > 0:

--- a/django_mongodb_engine/utils.py
+++ b/django_mongodb_engine/utils.py
@@ -70,8 +70,6 @@ class CollectionDebugWrapper(object):
         logger.debug(msg, extra={'duration': duration})
 
     def find(self, *args, **kwargs):
-        if not 'slave_okay' in kwargs and self.collection.slave_okay:
-            kwargs['slave_okay'] = True
         return DebugCursor(self, self.collection, *args, **kwargs)
 
     def logging_wrapper(method):

--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -29,12 +29,13 @@ MongoDB Engine does is lower-casing the names before passing the flags to
 
 .. _operations-setting:
 
-Safe Operations (``getLastError``)
-----------------------------------
+Acknowledged Operations
+-----------------------
 Use the ``OPERATIONS`` dict to specify extra flags passed to
 :meth:`Collection.save <pymongo.collection.Collection.save>`,
 :meth:`~pymongo.collection.Collection.update` or
-:meth:`~pymongo.collection.Collection.remove` (and thus to ``getLastError``):
+:meth:`~pymongo.collection.Collection.remove` (and thus included in the
+write concern):
 
 .. code-block:: python
 
@@ -43,19 +44,13 @@ Use the ``OPERATIONS`` dict to specify extra flags passed to
        ...
    }
 
-Since any options to ``getLastError`` imply ``safe=True``,
-this configuration passes ``safe=True, w=3`` as keyword arguments to each of
-:meth:`~pymongo.collection.Collection.save`,
-:meth:`~pymongo.collection.Collection.update` and
-:meth:`~pymongo.collection.Collection.remove`.
-
 Get a more fine-grained setup by introducing another layer to this dict:
 
 .. code-block:: python
 
    'OPTIONS' : {
        'OPERATIONS' : {
-           'save' : {'safe' : True},
+           'save' : {'w': 3},
            'update' : {},
            'delete' : {'fsync' : True}
        },

--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -3,9 +3,9 @@ Settings
 
 .. TODO fix highlighting
 
-Connection Settings
--------------------
-Additional flags may be passed to :class:`pymongo.Connection` using the
+Client Settings
+---------------
+Additional flags may be passed to :class:`pymongo.MongoClient` using the
 ``OPTIONS`` dictionary::
 
    DATABASES = {
@@ -14,9 +14,7 @@ Additional flags may be passed to :class:`pymongo.Connection` using the
            'NAME' : 'my_database',
            ...
            'OPTIONS' : {
-               'slave_okay' : True,
-               'tz_aware' : True,
-               'network_timeout' : 42,
+               'socketTimeoutMS' : 500,
                ...
            }
        }
@@ -24,8 +22,8 @@ Additional flags may be passed to :class:`pymongo.Connection` using the
 
 All of these settings directly mirror PyMongo settings.  In fact, all Django
 MongoDB Engine does is lower-casing the names before passing the flags to
-:class:`~pymongo.Connection`.  For a list of possible options head over to the
-`PyMongo documentation on connection options`_.
+:class:`~pymongo.MongoClient`.  For a list of possible options head over to the
+`PyMongo documentation on client options`_.
 
 .. _operations-setting:
 
@@ -52,7 +50,7 @@ Get a more fine-grained setup by introducing another layer to this dict:
        'OPERATIONS' : {
            'save' : {'w': 3},
            'update' : {},
-           'delete' : {'fsync' : True}
+           'delete' : {'j' : True}
        },
        ...
    }
@@ -64,10 +62,10 @@ Get a more fine-grained setup by introducing another layer to this dict:
    "`insert vs. update`" into `save`.
 
 
-A full list of ``getLastError`` flags may be found in the
-`MongoDB documentation <http://www.mongodb.org/display/DOCS/getLastError+Command>`_.
+A full list of write concern flags may be found in the
+`MongoDB documentation <http://docs.mongodb.org/manual/core/write-concern/>`_.
 
 .. _Similar to Django's built-in backends: 
    http://docs.djangoproject.com/en/dev/ref/settings/#std:setting-OPTIONS
-.. _PyMongo documentation on connection options: 
-   http://api.mongodb.org/python/current/api/pymongo/connection.html
+.. _PyMongo documentation on client options:
+   http://api.mongodb.org/python/current/api/pymongo/mongo_client.html

--- a/tests/mongodb/models.py
+++ b/tests/mongodb/models.py
@@ -92,7 +92,7 @@ class NewStyleIndexesTestModel(models.Model):
             {'fields': [('custom_column', -1), 'f3']},
             [('geo', '2d')],
             {'fields': [('geo_custom_column', '2d'), 'f2'],
-             'min': 42, 'max': 21},
+             'min': 21, 'max': 42},
             {'fields': [('dict1.foo', 1)]},
             {'fields': [('dict_custom_column.foo', 1)]},
             {'fields': [('embedded.a', 1)]},

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -248,20 +248,18 @@ class DatabaseOptionTests(TestCase):
                 self.assertEqual(method_kwargs[name],
                                  Collection._method_kwargs[name])
 
-            if Collection._method_kwargs['update'].get('safe'):
-                self.assertEqual(*update_count)
+            self.assertEqual(*update_count)
 
         test_setup({}, save={}, update={'multi': True}, remove={})
-        test_setup({
-            'safe': True},
-            save={'safe': True},
-            update={'safe': True, 'multi': True},
-            remove={'safe': True})
-        test_setup({
-            'delete': {'safe': True}, 'update': {}},
+        test_setup({},
             save={},
             update={'multi': True},
-            remove={'safe': True})
+            remove={})
+        test_setup({
+            'delete': {}, 'update': {}},
+            save={},
+            update={'multi': True},
+            remove={})
         test_setup({
             'insert': {'fsync': True}, 'delete': {'fsync': True}},
             save={},

--- a/tests/settings/settings_base.py
+++ b/tests/settings/settings_base.py
@@ -2,7 +2,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django_mongodb_engine',
         'NAME': 'test',
-        'OPTIONS': {'OPERATIONS': {'safe': True}},
+        'OPTIONS': {'OPERATIONS': {}},
     },
     'other': {
         'ENGINE': 'django_mongodb_engine',


### PR DESCRIPTION
"auto_start_request" option is gone, "max_pool_size" renamed to "maxPoolSize", "safe" is gone, "_connect" is renamed "connect".