### PR TITLE
Add the ability to remove connection options

### DIFF
--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -217,7 +217,8 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
         user = pop('USER')
         password = pop('PASSWORD')
         options = pop('OPTIONS', {})
-
+        options_removed = pop('OPTIONS_REMOVED', [])
+        
         self.operation_flags = options.pop('OPERATIONS', {})
         if not any(k in ['save', 'delete', 'update']
                    for k in self.operation_flags):
@@ -256,6 +257,8 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
             safe=False
         )
         conn_options.update(options)
+        for k in options_removed:
+            conn_options.pop(k, None)
 
         try:
             self.connection = connection_class(**conn_options)


### PR DESCRIPTION
It seems that the most recent version of Mongo rejects the connection when 'safe', '_connect','max_pool_size' or 'auto_start_request' are passed. This change allows us to specify the connection parameters to exclude from the DATABASES section of settings.py by adding a section 'OPTIONS_REMOVED': ['safe', '_connect','max_pool_size','auto_start_request']