### PR TITLE
authSource (--authenticationdatabase)

### DIFF
--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -264,8 +264,10 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
             exc_info = sys.exc_info()
             raise ImproperlyConfigured, exc_info[1], exc_info[2]
 
+        auth_source = options.get('authSource')
+
         if user and password:
-            if not self.database.authenticate(user, password):
+            if not self.database.authenticate(user, password, source=auth_source):
                 raise ImproperlyConfigured("Invalid username or password.")
 
         self.connected = True


### PR DESCRIPTION
Authenticate using the authSource option when supplied

This is required when the user's authentication credentials exist on a separate DB to the one we are connecting to (a more common scenario with the new MMS) 