### PR TITLE
Support for pymongo 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
     - env: DJANGO_VERSION=1.4
 
 install:
-  - pip install git+http://github.com/django-nonrel/django@nonrel-$DJANGO_VERSION
-  - pip install git+http://github.com/django-nonrel/django-dbindexer@master
-  - pip install git+http://github.com/django-nonrel/djangotoolbox@master
+  - pip install https://github.com/django-nonrel/django/tarball/nonrel-$DJANGO_VERSION
+  - pip install https://github.com/django-nonrel/django-dbindexer/tarball/master
+  - pip install https://github.com/django-nonrel/djangotoolbox/tarball/master
   - python setup.py install
 
 script: cd tests && python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.5
   - DJANGO_VERSION=1.6
+  - DJANGO_VERSION=1.7
 
 
 matrix:
   allow_failures:
     - env: DJANGO_VERSION=1.4
+    - env: DJANGO_VERSION=1.7
 
 install:
   - pip install git+http://github.com/django-nonrel/django@nonrel-$DJANGO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,18 @@ python:
 env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.5
+  - DJANGO_VERSION=1.6
   - DJANGO_VERSION=1.6-beta
+  - DJANGO_VERSION=1.7
 
 matrix:
   allow_failures:
     - env: DJANGO_VERSION=1.4
 
 install:
-  - pip install https://github.com/django-nonrel/django/tarball/nonrel-$DJANGO_VERSION
-  - pip install https://github.com/django-nonrel/django-dbindexer/tarball/master
-  - pip install https://github.com/django-nonrel/djangotoolbox/tarball/master
+  - pip install git+http://github.com/django-nonrel/django@nonrel-$DJANGO_VERSION
+  - pip install git+http://github.com/django-nonrel/django-dbindexer@master
+  - pip install git+http://github.com/django-nonrel/djangotoolbox@master
   - python setup.py install
 
 script: cd tests && python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,28 @@ python:
   - 2.7
 
 env:
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.5
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
+  - DJANGO_VERSION=1.4 PYMONGO_VERSION=2.8.1
+  - DJANGO_VERSION=1.4 PYMONGO_VERSION=3.0.2
+  - DJANGO_VERSION=1.5 PYMONGO_VERSION=2.8.1
+  - DJANGO_VERSION=1.5 PYMONGO_VERSION=3.0.2
+  - DJANGO_VERSION=1.6 PYMONGO_VERSION=2.8.1
+  - DJANGO_VERSION=1.6 PYMONGO_VERSION=3.0.2
+  - DJANGO_VERSION=1.7 PYMONGO_VERSION=2.8.1
+  - DJANGO_VERSION=1.7 PYMONGO_VERSION=3.0.2
 
 
 matrix:
   allow_failures:
-    - env: DJANGO_VERSION=1.4
-    - env: DJANGO_VERSION=1.7
+    - env: DJANGO_VERSION=1.4 PYMONGO_VERSION=2.8.1
+    - env: DJANGO_VERSION=1.4 PYMONGO_VERSION=3.0.2
+    - env: DJANGO_VERSION=1.7 PYMONGO_VERSION=2.8.1
+    - env: DJANGO_VERSION=1.7 PYMONGO_VERSION=3.0.2
 
 install:
   - pip install git+http://github.com/django-nonrel/django@nonrel-$DJANGO_VERSION
   - pip install git+http://github.com/django-nonrel/django-dbindexer@master
   - pip install git+http://github.com/django-nonrel/djangotoolbox@master
+  - pip install pymongo==$PYMONGO_VERSION --upgrade
   - python setup.py install
 
 script: cd tests && python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.5
   - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
 
 
 matrix:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,4 +23,4 @@ Contributions by
 * Brandon Pedersen (https://github.com/bpedman)
 
 (For an up-to-date list of contributors, see
-https://github.com/django-mongodb-engine/mongodb-engine/contributors.)
+https://github.com/django-nonrel/mongodb-engine/contributors.)

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -60,11 +60,20 @@ class DatabaseOperations(NonrelDatabaseOperations):
         drop all `tables`. No SQL in MongoDB, so just clear all tables
         here and return an empty list.
         """
+
+
+
         for table in tables:
             if table.startswith('system.'):
                 # Do not try to drop system collections.
                 continue
-            self.connection.database[table].remove()
+
+            collection = self.connection.database[table]
+            options = collection.options()
+
+            if not options.get('capped', False):
+                collection.delete_many({})
+
         return []
 
     def validate_autopk_value(self, value):

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -252,8 +252,7 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
             document_class=dict,
             tz_aware=False,
             _connect=True,
-            auto_start_request=True,
-            safe=False
+            auto_start_request=True
         )
         conn_options.update(options)
 

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -76,7 +76,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
             if not options.get('capped', False):
 
                 # TODO:Not backwards compatible
-                collection.delete_many({})
+                collection.remove({})
 
         return []
 
@@ -253,9 +253,6 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
                 warnings.warn("slave_okay has been deprecated. "
                               "Please use read_preference instead.")
 
-
-
-
         conn_options = dict(
             host=host,
             port=int(port),
@@ -264,8 +261,13 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
         )
         conn_options.update(options)
 
+        if replicaset:
+            connection_class = MongoReplicaSetClient
+        else:
+            connection_class = MongoClient
+
         try:
-            self.connection = MongoClient(**conn_options)
+            self.connection = connection_class(**conn_options)
             self.database = self.connection[db_name]
         except TypeError:
             exc_info = sys.exc_info()

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -74,8 +74,6 @@ class DatabaseOperations(NonrelDatabaseOperations):
             options = collection.options()
 
             if not options.get('capped', False):
-
-                # TODO:Not backwards compatible
                 collection.remove({})
 
         return []

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -38,7 +38,7 @@ from .utils import CollectionDebugWrapper
 class DatabaseFeatures(NonrelDatabaseFeatures):
     supports_microsecond_precision = False
     supports_long_model_names = False
-    distinguishes_insert_from_update = True
+    #distinguishes_insert_from_update = True
 
 
 class DatabaseOperations(NonrelDatabaseOperations):

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -240,24 +240,19 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
                 warnings.warn("slave_okay has been deprecated. "
                               "Please use read_preference instead.")
 
-        if replicaset:
-            connection_class = MongoReplicaSetClient
-        else:
-            connection_class = MongoClient
+
+
 
         conn_options = dict(
             host=host,
             port=int(port),
-            max_pool_size=None,
             document_class=dict,
-            tz_aware=False,
-            _connect=True,
-            auto_start_request=True
+            tz_aware=False
         )
         conn_options.update(options)
 
         try:
-            self.connection = connection_class(**conn_options)
+            self.connection = MongoClient(**conn_options)
             self.database = self.connection[db_name]
         except TypeError:
             exc_info = sys.exc_info()

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -38,7 +38,8 @@ from .utils import CollectionDebugWrapper
 class DatabaseFeatures(NonrelDatabaseFeatures):
     supports_microsecond_precision = False
     supports_long_model_names = False
-    #distinguishes_insert_from_update = True
+
+    can_rollback_ddl = True
 
 
 class DatabaseOperations(NonrelDatabaseOperations):

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -100,8 +100,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
 
             # Provide a better message for invalid IDs.
             except (TypeError, InvalidId):
-                assert isinstance(value, (str, unicode))
-                if len(value) > 13:
+                if isinstance(value, (str, unicode)) and len(value) > 13:
                     value = value[:10] + '...'
                 msg = "AutoField (default primary key) values must be " \
                       "strings representing an ObjectId on MongoDB (got " \

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -99,7 +99,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
                 return ObjectId(value)
 
             # Provide a better message for invalid IDs.
-            except InvalidId:
+            except (TypeError, InvalidId):
                 assert isinstance(value, (str, unicode))
                 if len(value) > 13:
                     value = value[:10] + '...'

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -136,7 +136,7 @@ class MongoQuery(NonrelQuery):
             return []
 
         fields = get_selected_fields(self.query)
-        cursor = self.collection.find(self.mongo_query, fields=fields)
+        cursor = self.collection.find(self.mongo_query, fields)
         if self.ordering:
             cursor.sort(self.ordering)
         if self.query.low_mark > 0:

--- a/django_mongodb_engine/utils.py
+++ b/django_mongodb_engine/utils.py
@@ -70,7 +70,6 @@ class CollectionDebugWrapper(object):
         logger.debug(msg, extra={'duration': duration})
 
     def find(self, *args, **kwargs):
-
         return DebugCursor(self, self.collection, *args, **kwargs)
 
     def logging_wrapper(method):

--- a/django_mongodb_engine/utils.py
+++ b/django_mongodb_engine/utils.py
@@ -70,8 +70,7 @@ class CollectionDebugWrapper(object):
         logger.debug(msg, extra={'duration': duration})
 
     def find(self, *args, **kwargs):
-        if not 'slave_okay' in kwargs and self.collection.slave_okay:
-            kwargs['slave_okay'] = True
+
         return DebugCursor(self, self.collection, *args, **kwargs)
 
     def logging_wrapper(method):

--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -3,9 +3,9 @@ Settings
 
 .. TODO fix highlighting
 
-Connection Settings
+Client Settings
 -------------------
-Additional flags may be passed to :class:`pymongo.Connection` using the
+Additional flags may be passed to :class:`pymongo.MongoClient` using the
 ``OPTIONS`` dictionary::
 
    DATABASES = {
@@ -14,9 +14,7 @@ Additional flags may be passed to :class:`pymongo.Connection` using the
            'NAME' : 'my_database',
            ...
            'OPTIONS' : {
-               'slave_okay' : True,
-               'tz_aware' : True,
-               'network_timeout' : 42,
+               'socketTimeoutMS' : 500,
                ...
            }
        }
@@ -24,17 +22,17 @@ Additional flags may be passed to :class:`pymongo.Connection` using the
 
 All of these settings directly mirror PyMongo settings.  In fact, all Django
 MongoDB Engine does is lower-casing the names before passing the flags to
-:class:`~pymongo.Connection`.  For a list of possible options head over to the
-`PyMongo documentation on connection options`_.
+:class:`~pymongo.MongoClient`.  For a list of possible options head over to the
+`PyMongo documentation on client options`_.
 
 .. _operations-setting:
 
-Safe Operations (``getLastError``)
-----------------------------------
+Acknowledged Operations
+-----------------------
 Use the ``OPERATIONS`` dict to specify extra flags passed to
 :meth:`Collection.save <pymongo.collection.Collection.save>`,
 :meth:`~pymongo.collection.Collection.update` or
-:meth:`~pymongo.collection.Collection.remove` (and thus to ``getLastError``):
+:meth:`~pymongo.collection.Collection.remove` (and thus included in the write concern):
 
 .. code-block:: python
 
@@ -43,11 +41,7 @@ Use the ``OPERATIONS`` dict to specify extra flags passed to
        ...
    }
 
-Since any options to ``getLastError`` imply ``safe=True``,
-this configuration passes ``safe=True, w=3`` as keyword arguments to each of
-:meth:`~pymongo.collection.Collection.save`,
-:meth:`~pymongo.collection.Collection.update` and
-:meth:`~pymongo.collection.Collection.remove`.
+
 
 Get a more fine-grained setup by introducing another layer to this dict:
 
@@ -55,9 +49,9 @@ Get a more fine-grained setup by introducing another layer to this dict:
 
    'OPTIONS' : {
        'OPERATIONS' : {
-           'save' : {'safe' : True},
+           'save' : {'w' : 3},
            'update' : {},
-           'delete' : {'fsync' : True}
+           'delete' : {'j' : True}
        },
        ...
    }
@@ -69,10 +63,10 @@ Get a more fine-grained setup by introducing another layer to this dict:
    "`insert vs. update`" into `save`.
 
 
-A full list of ``getLastError`` flags may be found in the
-`MongoDB documentation <http://www.mongodb.org/display/DOCS/getLastError+Command>`_.
+A full list of write concern flags may be found in the
+`MongoDB documentation <http://docs.mongodb.org/manual/core/write-concern/>`_.
 
 .. _Similar to Django's built-in backends: 
    http://docs.djangoproject.com/en/dev/ref/settings/#std:setting-OPTIONS
-.. _PyMongo documentation on connection options: 
-   http://api.mongodb.org/python/current/api/pymongo/connection.html
+.. _PyMongo documentation on client options:
+   http://api.mongodb.org/python/current/api/pymongo/mongo_client.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
-pymongo>=3.0
+pymongo>=2.8
 
 https://github.com/django-nonrel/djangotoolbox/tarball/master
 https://github.com/django-nonrel/django/tarball/nonrel-1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymongo
+pymongo>=3.0
 https://github.com/django-nonrel/djangotoolbox/tarball/master
 https://github.com/django-nonrel/django/tarball/nonrel-1.5
 https://github.com/django-nonrel/django-dbindexer/tarball/master

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='django-mongodb-engine',
     license='2-clause BSD',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    install_requires=['pymongo', 'djangotoolbox>=1.6.0'],
+    install_requires=['pymongo>=3.0', 'djangotoolbox>=1.6.0'],
     packages=find_packages(exclude=['tests', 'tests.*']),
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='django-mongodb-engine',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
 
-    install_requires=['pymongo>=3.0', 'djangotoolbox>=1.6.0'],
+    install_requires=['pymongo>=2.8', 'djangotoolbox>=1.6.0'],
 
     packages=find_packages(exclude=['tests', 'tests.*']),
     zip_safe=False,

--- a/tests/contrib/tests.py
+++ b/tests/contrib/tests.py
@@ -121,6 +121,9 @@ class MapReduceTests(TestCase):
 class RawQueryTests(TestCase):
 
     def setUp(self):
+
+        MapReduceModel.objects.all().delete()
+
         for i in xrange(10):
             MapReduceModel.objects.create(n=i, m=i * 2)
 
@@ -155,6 +158,10 @@ class RawQueryTests(TestCase):
 
 # TODO: Line breaks.
 class FullTextTest(TestCase):
+
+    def setUp(self):
+        Post.objects.all().delete()
+
 
     def test_simple_fulltext(self):
         blog = Post(content="simple, full text.... search? test")

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -18,6 +18,11 @@ from models import Author, Article, Tag
 class LookupTests(TestCase):
 
     def setUp(self):
+
+        Author.objects.all().delete()
+        Article.objects.all().delete()
+        Tag.objects.all().delete()
+
         # Create a few Authors.
         self.au1 = Author(name='Author 1')
         self.au1.save()

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from operator import attrgetter
 
 from django.core.exceptions import FieldError
-from django.db import connection
 from django.db.utils import DatabaseError
 from django.test import TestCase, skipUnlessDBFeature
 
@@ -18,15 +17,6 @@ from models import Author, Article, Tag
 class LookupTests(TestCase):
 
     def setUp(self):
-
-        Author.objects.all().delete()
-        Article.objects.all().delete()
-        Tag.objects.all().delete()
-
-        # Create a few Authors.
-        Author.objects.all().delete()
-        Article.objects.all().delete()
-        Tag.objects.all().delete()
 
         self.au1 = Author(name='Author 1')
         self.au1.save()

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -6,7 +6,6 @@ from django.contrib.sites.models import Site
 from django.db import connection
 from django.db.utils import DatabaseError, IntegrityError
 from django.db.models import Q
-from encodings.big5 import codec
 from gridfs import GridOut
 from pymongo import ASCENDING, DESCENDING, ReadPreference, version_tuple as pymongo_version
 from django_mongodb_engine.base import DatabaseWrapper

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -3,13 +3,14 @@ from cStringIO import StringIO
 
 from django.core.management import call_command
 from django.contrib.sites.models import Site
-from django.db import connection
 from django.db.utils import DatabaseError, IntegrityError
 from django.db.models import Q
 from gridfs import GridOut
 from pymongo import ASCENDING, DESCENDING
 from django_mongodb_engine.base import DatabaseWrapper
 from models import *
+from pymongo.collection import Collection
+
 from utils import *
 
 
@@ -199,7 +200,6 @@ class DatabaseOptionTests(TestCase):
 
         with self.custom_database_wrapper({
                 'OPTIONS': {
-                    'SLAVE_OKAY': True,
                     'TZ_AWARE': True,
                     'DOCUMENT_CLASS': foodict,
                 }}) as connection:

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -3,15 +3,12 @@ from cStringIO import StringIO
 
 from django.core.management import call_command
 from django.contrib.sites.models import Site
-from django.db import connection, connections
+from django.db import connection
 from django.db.utils import DatabaseError, IntegrityError
 from django.db.models import Q
-
 from gridfs import GridOut
 from pymongo import ASCENDING, DESCENDING
-
 from django_mongodb_engine.base import DatabaseWrapper
-
 from models import *
 from utils import *
 
@@ -57,7 +54,6 @@ class MongoDBEngineTests(TestCase):
     def test_databasewrapper_api(self):
         from pymongo.mongo_client import MongoClient
         from pymongo.database import Database
-        from pymongo.collection import Collection
         from random import shuffle
 
         if settings.DEBUG:

--- a/tests/mongodb/tests.py
+++ b/tests/mongodb/tests.py
@@ -3,13 +3,15 @@ from cStringIO import StringIO
 
 from django.core.management import call_command
 from django.contrib.sites.models import Site
+from django.db import connection
 from django.db.utils import DatabaseError, IntegrityError
 from django.db.models import Q
+from encodings.big5 import codec
 from gridfs import GridOut
 from pymongo import ASCENDING, DESCENDING
 from django_mongodb_engine.base import DatabaseWrapper
 from models import *
-from pymongo.collection import Collection
+
 
 from utils import *
 
@@ -56,16 +58,16 @@ class MongoDBEngineTests(TestCase):
         from pymongo.mongo_client import MongoClient
         from pymongo.database import Database
         from random import shuffle
+        from pymongo.collection import Collection
 
         if settings.DEBUG:
-            from django_mongodb_engine.utils import \
-                CollectionDebugWrapper as Collection
+            from django_mongodb_engine.utils import CollectionDebugWrapper as Collection
+
 
         for wrapper in [connection,
                         DatabaseWrapper(connection.settings_dict)]:
             calls = [
-                lambda: self.assertIsInstance(wrapper.get_collection('foo'),
-                                              Collection),
+                lambda: self.assertIsInstance(wrapper.get_collection('foo'), Collection),
                 lambda: self.assertIsInstance(wrapper.database, Database),
                 lambda: self.assertIsInstance(wrapper.connection, MongoClient),
             ]
@@ -176,6 +178,10 @@ class RegressionTests(TestCase):
 class DatabaseOptionTests(TestCase):
     """Tests for MongoDB-specific database options."""
 
+    def setUp(self):
+        Post.objects.all().delete()
+        RawModel.objects.all().delete()
+
     class custom_database_wrapper(object):
 
         def __init__(self, settings, **kwargs):
@@ -190,7 +196,7 @@ class DatabaseOptionTests(TestCase):
             return self.new_wrapper
 
         def __exit__(self, *exc_info):
-            self.new_wrapper.connection.disconnect()
+            self.new_wrapper.connection.close()
             connections._connections.default = self._old_connection
 
     def test_pymongo_connection_args(self):
@@ -198,24 +204,25 @@ class DatabaseOptionTests(TestCase):
         class foodict(dict):
             pass
 
+        tz_aware = True
+        document_class = foodict
+
         with self.custom_database_wrapper({
                 'OPTIONS': {
                     'TZ_AWARE': True,
                     'DOCUMENT_CLASS': foodict,
                 }}) as connection:
-            for name, value in connection.settings_dict[
-                    'OPTIONS'].iteritems():
-                name = '_Connection__%s' % name.lower()
-                if name not in connection.connection.__dict__:
-                    # slave_okay was moved into BaseObject in PyMongo 2.0.
-                    name = name.replace('Connection', 'BaseObject')
-                if name not in connection.connection.__dict__:
-                    # document_class was moved into MongoClient in PyMongo 2.4.
-                    name = name.replace('BaseObject', 'MongoClient')
-                self.assertEqual(connection.connection.__dict__[name], value)
+
+            codec_options = connection.connection.codec_options
+
+            self.assertEqual(codec_options.tz_aware, tz_aware)
+            self.assertEqual(codec_options.document_class, document_class)
+
+
 
     def test_operation_flags(self):
         def test_setup(flags, **method_kwargs):
+
             cls_code = [
                 'from pymongo.collection import Collection',
                 'class Collection(Collection):',
@@ -233,43 +240,30 @@ class DatabaseOptionTests(TestCase):
             exec '\n'.join(cls_code) in locals()
 
             options = {'OPTIONS': {'OPERATIONS': flags}}
-            with self.custom_database_wrapper(options,
-                                              collection_class=Collection):
+            with self.custom_database_wrapper(options, collection_class=Collection):
                 RawModel.objects.create(raw='foo')
                 update_count = RawModel.objects.update(raw='foo'), \
                                RawModel.objects.count()
                 RawModel.objects.all().delete()
 
             for name in method_kwargs:
-                self.assertEqual(method_kwargs[name],
-                                 Collection._method_kwargs[name])
+                self.assertEqual(method_kwargs[name], Collection._method_kwargs[name])
 
-            if Collection._method_kwargs['update'].get('safe'):
-                self.assertEqual(*update_count)
 
         test_setup({}, save={}, update={'multi': True}, remove={})
-        test_setup({
-            'safe': True},
-            save={'safe': True},
-            update={'safe': True, 'multi': True},
-            remove={'safe': True})
-        test_setup({
-            'delete': {'safe': True}, 'update': {}},
+        test_setup({},
             save={},
             update={'multi': True},
-            remove={'safe': True})
-        test_setup({
-            'insert': {'fsync': True}, 'delete': {'fsync': True}},
+            remove={})
+        test_setup({'delete': {}, 'update': {}},
+            save={},
+            update={'multi': True},
+            remove={})
+        test_setup({'insert': {'fsync': True}, 'delete': {'fsync': True}},
             save={},
             update={'multi': True},
             remove={'fsync': True})
 
-    def test_unique(self):
-        with self.custom_database_wrapper({'OPTIONS': {}}):
-            Post.objects.create(title='a', content='x')
-            Post.objects.create(title='a', content='y')
-            self.assertEqual(Post.objects.count(), 1)
-            self.assertEqual(Post.objects.get().content, 'x')
 
     def test_unique_safe(self):
         Post.objects.create(title='a')
@@ -341,9 +335,12 @@ class NewStyleIndexTests(TestCase):
         info = get_collection(NewStyleIndexesTestModel).index_information()
         index_name = '_'.join('%s_%s' % pair for pair in key)
         default_properties = {'key': self.order_doesnt_matter(key), 'v': 1}
+
         self.assertIn(index_name, info)
-        self.assertEqual(info[index_name],
-                         dict(default_properties, **properties))
+
+        for key, value in dict(default_properties, **properties).iteritems():
+            self.assertEqual(info[index_name][key], value)
+
 
     def test_indexes(self):
         self.assertHaveIndex([('db_index', 1)])

--- a/tests/settings/settings_base.py
+++ b/tests/settings/settings_base.py
@@ -2,7 +2,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django_mongodb_engine',
         'NAME': 'test',
-        'OPTIONS': {'OPERATIONS': {'safe': True}},
+        'OPTIONS': {'OPERATIONS': {}},
     },
     'other': {
         'ENGINE': 'django_mongodb_engine',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,19 +11,6 @@ class TestCase(TestCase):
         if getattr(settings, 'TEST_DEBUG', False):
             settings.DEBUG = True
 
-
-    def _fixture_teardown(self):
-        from django.db import connections
-        for connection_name in connections:
-
-            db_wrapper = connections[connection_name]
-
-            for collection_name in db_wrapper.database.collection_names(include_system_collections=False):
-                db_wrapper.get_collection(collection_name).drop()
-
-
-
-
     def assertEqualLists(self, a, b):
         self.assertEqual(list(a), list(b))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,13 +4,25 @@ from django.db.models import Model
 from django.test import TestCase
 from django.utils.unittest import skip
 
-
 class TestCase(TestCase):
 
     def setUp(self):
         super(TestCase, self).setUp()
         if getattr(settings, 'TEST_DEBUG', False):
             settings.DEBUG = True
+
+
+    def _fixture_teardown(self):
+        from django.db import connections
+        for connection_name in connections:
+
+            db_wrapper = connections[connection_name]
+
+            for collection_name in db_wrapper.database.collection_names(include_system_collections=False):
+                db_wrapper.get_collection(collection_name).drop()
+
+
+
 
     def assertEqualLists(self, a, b):
         self.assertEqual(list(a), list(b))


### PR DESCRIPTION
Support for Pymongo 3.0.
- Removed use of the `fields` keyword argument when calling find, as this has changed to `projection` in pymongo 3.0. Use positional argument instead.
- Have removed the use  of `safe` and `slave_okay` keyword arguments as these are no longer used and have been deprecated since 2.4


Fix the broken tests.
 - Have changed the `DatabaseOperation.sqlflush` method to now check if a collection is capped before trying to remove the data
 - Removed tests that are no longer relevant.



Fixes #207 and #209 