### PR TITLE
Fix erroneous code reference in tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -139,7 +139,7 @@ To embed instances of models into other models, we can use
 :doc:`EmbeddedModelField <topics/embedded-models>`:
 
 .. literalinclude:: code/tutorial/v2/nonrelblog/models.py
-   :lines: 10-21
+   :lines: 13-22
    :prepend: from djangotoolbox.fields import EmbeddedModelField
 
 Let's hop into the Django shell and test this:


### PR DESCRIPTION
From:

```
from djangotoolbox.fields import EmbeddedModelField
    tags = ListField()
    comments = ListField(EmbeddedModelField('Comment')) # <---


class Comment(models.Model):
    created_on = models.DateTimeField(auto_now_add=True)
    [...]
```

to:

```
from djangotoolbox.fields import EmbeddedModelField

class Comment(models.Model):
    created_on = models.DateTimeField(auto_now_add=True)
    [...]
```