### PR TITLE
docs: Fix a few typos

### DIFF
--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -126,7 +126,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
                            "valid ObjectId string."
                 raise DatabaseError(msg)
 
-        # PyMongo can only process datatimes?
+        # PyMongo can only process datetimes?
         elif db_type == 'date':
             return datetime.datetime(value.year, value.month, value.day)
         elif db_type == 'time':

--- a/django_mongodb_engine/contrib/search/fields.py
+++ b/django_mongodb_engine/contrib/search/fields.py
@@ -29,7 +29,7 @@ class TokenizedField(models.Field):
             value = ''.join(value)
 
         # When 'exact' is used we'll perform an exact_phrase query
-        # using the $all operator otherwhise we'll just tokenized
+        # using the $all operator otherwise we'll just tokenized
         # the value. Djangotoolbox will do the remaining checks.
         if lookup_type == 'exact':
             return {'$all': self._tokenizer.tokenize(value)}

--- a/django_mongodb_engine/fields.py
+++ b/django_mongodb_engine/fields.py
@@ -114,7 +114,7 @@ class GridFSField(models.Field):
 
     def _on_pre_delete(self, sender, instance, using, signal, **kwargs):
         """
-        Deletes the files associated with this isntance.
+        Deletes the files associated with this instance.
 
         If versioning is enabled all versions will be deleted.
         """

--- a/django_mongodb_engine/storage.py
+++ b/django_mongodb_engine/storage.py
@@ -26,7 +26,7 @@ class GridFSStorage(Storage):
     This backend aims to add a GridFS storage to upload files to
     using Django's file fields.
 
-    For performance, the file hirarchy is represented as a tree of
+    For performance, the file hierarchy is represented as a tree of
     MongoDB sub-collections.
 
     (One could use a flat list, but to list a directory '/this/path/'

--- a/docs/source/topics/lists-and-dicts.rst
+++ b/docs/source/topics/lists-and-dicts.rst
@@ -96,5 +96,5 @@ as the are required to be strings on MongoDB.) ::
    {u'bob' : 3, u'alice' : 42}
 
 DictFields are useful mainly for storing objects of varying shape, i.e. objects
-whose structure is unknow at coding time.  If all your objects have the same
+whose structure is unknown at coding time.  If all your objects have the same
 structure, you should consider using :doc:`embedded-models`.

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -275,7 +275,7 @@ class QueryTestCase(TestCase):
         alice_profile = UserProfile.objects.using('default').get(flavor='chocolate')
         bob_profile = UserProfile.objects.using('other').get(flavor='crunchy frog')
 
-        # Retrive related object by descriptor. Related objects should be database-baound
+        # Retrive related object by descriptor. Related objects should be database-bound
         self.assertEqual(alice_profile.user.username, 'alice')
         self.assertEqual(bob_profile.user.username, 'bob')
 
@@ -466,7 +466,7 @@ class RouterTestCase(TestCase):
         self.assertEqual(Book.objects.db_manager('default').all().db, 'default')
 
     def test_syncdb_selection(self):
-        "Synchronization behaviour is predicatable"
+        "Synchronization behaviour is predictable"
 
         self.assertTrue(router.allow_syncdb('default', User))
         self.assertTrue(router.allow_syncdb('default', Book))

--- a/tests/query/tests.py
+++ b/tests/query/tests.py
@@ -398,7 +398,7 @@ class UpdateTests(TestCase):
         self.assertEqual(Person.objects.get(name='john').age, 39)
 
     def test_update_with_F_and_db_column(self):
-        # This test is simmilar to test_update_with_F but tests
+        # This test is similar to test_update_with_F but tests
         # the update with a column that has a db_column set.
         john = Person.objects.create(name='john', surname='nhoj',
                                      another_age=42)


### PR DESCRIPTION
There are small typos in:
- django_mongodb_engine/base.py
- django_mongodb_engine/contrib/search/fields.py
- django_mongodb_engine/fields.py
- django_mongodb_engine/storage.py
- docs/source/topics/lists-and-dicts.rst
- tests/multiple_database/tests.py
- tests/query/tests.py

Fixes:
- Should read `unknown` rather than `unknow`.
- Should read `similar` rather than `simmilar`.
- Should read `predictable` rather than `predicatable`.
- Should read `otherwise` rather than `otherwhise`.
- Should read `instance` rather than `isntance`.
- Should read `hierarchy` rather than `hirarchy`.
- Should read `datetimes` rather than `datatimes`.
- Should read `bound` rather than `baound`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md